### PR TITLE
Add notifyfail() call

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/telos-oracle-scripts.iml" filepath="$PROJECT_DIR$/.idea/telos-oracle-scripts.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/telos-oracle-scripts.iml
+++ b/.idea/telos-oracle-scripts.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "telos-requestor",
+  "name": "telos-oracle-scripts",
   "version": "1.0.0",
-  "description": "Telos oracle request system",
+  "description": "Telos Oracle Scripts",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/src/Listener.js
+++ b/src/Listener.js
@@ -31,6 +31,7 @@ class Listener {
         if(this.checking_table === false){
             this.log(`${name}: Doing table check...`);
             this.checking_table = true;
+            let count = 0;
             let more = true;
             while(more){
                 try {
@@ -41,6 +42,8 @@ class Listener {
                         limit: 500,
                         lower_bound: this.next_key
                     });
+                    count += results.rows.length;
+                    console.log(`Table check has processed ${count} request rows`);
                     results.rows.forEach(async(row) => {
                         await callback(row);
                     });

--- a/src/Listener.js
+++ b/src/Listener.js
@@ -1,6 +1,6 @@
 const HyperionStreamClient = require("@eosrio/hyperion-stream-client").default;
 const fetch = require("node-fetch");
-const nameToNumber = require('./utils/anteloppeName');
+const nameToInt = require('./utils/anteloppeName');
 
 class Listener {
     constructor(
@@ -22,6 +22,8 @@ class Listener {
         this.counter = 0;
         this.checking_table = false;
         this.next_key = '';
+        this.lastReceivedBlock = 0;
+        this.streamClient = null;
     }
 
     // RPC ANTELOPE TABLE CHECK
@@ -62,15 +64,19 @@ class Listener {
     async startStream(name, account, table, scope, callback){
         let getInfo = await this.rpc.get_info();
         let headBlock = getInfo.head_block_num;
+        this.lastReceivedBlock = headBlock;
+        this.log(`${name}: Starting Hyperion Stream ...`);
         this.streamClient = new HyperionStreamClient(
             this.hyperion,
             {
                 async: true,
                 fetch: fetch,
+                debug: true,
+                endpoint: this.hyperion,
             }
         );
-        this.streamClient.lastReceivedBlock = headBlock;
         this.streamClient.onConnect = () => {
+            this.log(`${name}: Connecting to Hyperion Stream ...`);
             this.streamClient.streamDeltas({
                 code: account,
                 table: table,
@@ -81,27 +87,28 @@ class Listener {
             });
         };
         this.streamClient.onData = async (data, ack) => {
-            this.streamClient.lastReceivedBlock = data.block_num;
-            if (data.content.present && scope === parseInt(nameToNumber(data.content.scope).toString()) || data.content.present && scope === data.content.scope.toString()) {
+            this.lastReceivedBlock = data.block_num;
+            if (data.content.present && scope === nameToInt(data.content.scope) || data.content.present && scope === data.content.scope.toString()) {
                 await callback(data);
             }
             ack();
         };
-        this.streamClient.connect(() => {
-            this.log(`${name}: Connected to Hyperion Stream...`);
-        });
 
         let interval = setInterval(async () => {
-            if(typeof this.streamClient.lastReceivedBlock !== "undefined" && this.streamClient.lastReceivedBlock !== 0){
+            if(this.lastReceivedBlock !== 0){
                 let getInfo = await this.rpc.get_info();
-                if(this.max_block_diff < ( getInfo.head_block_num - this.streamClient.lastReceivedBlock)){
+                if(this.max_block_diff < ( getInfo.head_block_num - this.lastReceivedBlock)){
                     clearInterval(interval);
-                    this.log(`${name}: Restarting stream...`);
+                    this.log(`${name}: Restarting Hyperion Stream...`);
                     this.streamClient.disconnect();
                     await this.startStream(name, account, table, scope, callback);
                 }
             }
-        }, this.check_interval_ms)
+        }, this.check_interval_ms);
+
+        await this.streamClient.connect(() => {
+            this.log(`${name}: Connected to Hyperion Stream !`);
+        });
     }
 
     // LOG UTIL

--- a/src/listeners/RNGRequestListener.js
+++ b/src/listeners/RNGRequestListener.js
@@ -74,11 +74,7 @@ class RNGRequestListener extends Listener {
                         },
                     ],
                 },
-<<<<<<< HEAD
-                { blocksBehind: 10, expireSeconds: 120 }
-=======
-                { blocksBehind: 100, expireSeconds: 600 }
->>>>>>> 93c0ecf88b492cf8183907c4bf5f7f2ddf4dbdf6
+                { blocksBehind: 10, expireSeconds: 600 }
             );
             this.log(`RNG Oracle Request: Signed request ${row.request_id}`);
             setTimeout(function () {
@@ -108,7 +104,7 @@ class RNGRequestListener extends Listener {
                             },
                         ],
                     },
-                    { blocksBehind: 10, expireSeconds: 120 }
+                    { blocksBehind: 10, expireSeconds: 600 }
                 );
             } catch (e) {
                 this.log(`RNG Oracle Request: Calling notifyfail() failed: ${e}`);

--- a/src/listeners/RNGRequestListener.js
+++ b/src/listeners/RNGRequestListener.js
@@ -74,7 +74,11 @@ class RNGRequestListener extends Listener {
                         },
                     ],
                 },
+<<<<<<< HEAD
                 { blocksBehind: 10, expireSeconds: 120 }
+=======
+                { blocksBehind: 100, expireSeconds: 600 }
+>>>>>>> 93c0ecf88b492cf8183907c4bf5f7f2ddf4dbdf6
             );
             this.log(`RNG Oracle Request: Signed request ${row.request_id}`);
             setTimeout(function () {

--- a/src/listeners/RNGRequestListener.js
+++ b/src/listeners/RNGRequestListener.js
@@ -74,7 +74,7 @@ class RNGRequestListener extends Listener {
                         },
                     ],
                 },
-                { blocksBehind: 10, expireSeconds: 60 }
+                { blocksBehind: 10, expireSeconds: 120 }
             );
             this.log(`RNG Oracle Request: Signed request ${row.request_id}`);
             setTimeout(function () {
@@ -82,7 +82,33 @@ class RNGRequestListener extends Listener {
             }, this.check_interval_ms) // Timeout the size of check interval
             return result;
         } catch (e) {
-            console.error(`RNG Oracle Request: Submitting signature for request ${row.request_id} failed: ${e}`);
+            this.log(`RNG Oracle Request: Submitting signature for request ${row.request_id} failed: ${e}`);
+            try {
+                this.log(`RNG Oracle Request: Calling notifyfail()`);
+                const result = await this.api.transact(
+                    {
+                        actions: [
+                            {
+                                account: this.oracle,
+                                name: "notifyfail",
+                                authorization: [
+                                    {
+                                        actor: this.caller.name,
+                                        permission: this.caller.permission,
+                                    },
+                                ],
+                                data: {
+                                    request_id: row.request_id,
+                                    oracle_name: this.caller.name,
+                                },
+                            },
+                        ],
+                    },
+                    { blocksBehind: 10, expireSeconds: 120 }
+                );
+            } catch (e) {
+                this.log(`RNG Oracle Request: Calling notifyfail() failed: ${e}`);
+            }
             setTimeout(function () {
                 ctx.removeProcessingRequest(row.request_id);
             }, 1200000) // Big timeout so we don't retry endlessly if there is a request stuck

--- a/src/listeners/RNGRequestListener.js
+++ b/src/listeners/RNGRequestListener.js
@@ -74,7 +74,7 @@ class RNGRequestListener extends Listener {
                         },
                     ],
                 },
-                { blocksBehind: 10, expireSeconds: 600 }
+                { blocksBehind: 100, expireSeconds: 600 }
             );
             this.log(`RNG Oracle Request: Signed request ${row.request_id}`);
             setTimeout(function () {
@@ -104,7 +104,7 @@ class RNGRequestListener extends Listener {
                             },
                         ],
                     },
-                    { blocksBehind: 10, expireSeconds: 600 }
+                    { blocksBehind: 100, expireSeconds: 600 }
                 );
             } catch (e) {
                 this.log(`RNG Oracle Request: Calling notifyfail() failed: ${e}`);

--- a/src/utils/anteloppeName.js
+++ b/src/utils/anteloppeName.js
@@ -1,12 +1,12 @@
 const { createInitialTypes, SerialBuffer } = require('eosjs/dist/eosjs-serialize');
 
-function nameToNumber(name){
+function nameToInt(name){
     const builtinTypes = createInitialTypes()
     const typeUint64 = builtinTypes.get("uint64")
     const typeName = builtinTypes.get("name")
     var buffer = new SerialBuffer({ textDecoder: new TextDecoder(), textEncoder: new TextEncoder() });
 
     typeName.serialize(buffer, name)
-    return typeUint64.deserialize(buffer)
+    return parseInt(typeUint64.deserialize(buffer))
 }
-module.exports = nameToNumber;
+module.exports = nameToInt;


### PR DESCRIPTION
# Fixes #7 

## Description

This PR adds a call to notifyfail() on rng.oracle if submitting a number to requestor fails

## Test scenarios

A requests that fails to deliver a random number to a requestor (ie: callback error) should be deleted after 2 tries from 2 different oracles.

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
